### PR TITLE
feat: Support EcmaScript 2021 and 2022.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ module.exports = {
     es6: true
   },
   parserOptions: {
-    ecmaVersion: 2020
+    ecmaVersion: 2022
   },
   rules: {
     'prettier/prettier': [


### PR DESCRIPTION
### Details

So far, the ESLint rules only supported EcmaScript up to version 2020. This PR introduces support for ES2021 and ES2022.