### PR TITLE
fix: Ignore typescript files from node js projects when doing depcheck

### DIFF
--- a/bin/bot
+++ b/bin/bot
@@ -23,7 +23,7 @@ shell.exec('eslint . --ignore-path .gitignore --color', (codeEslint) => {
     shell.echo('Checking for missing or unused dependencies...');
     shell.echo('');
     shell.exec(
-      'depcheck --ignores "@sealsystems/semantic-release,assertthat,eslint-*"',
+      'depcheck --ignores "@sealsystems/semantic-release,assertthat,eslint-*" --ignore-patterns=*.ts',
       (codeDepcheck, stdoutDepcheck) => {
         if (codeDepcheck !== 0) {
           // Treat only missing dependencies as error


### PR DESCRIPTION
The **_seal-configurator-server_** project uses additional TS files to simulate type checking. Those adjacent files contain dependencies not found by the depcheck.
This change maked depcheck ignore any ts files found in the projects.